### PR TITLE
Use https protocol for submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "includes/vendor/wds-wp-json-api-connect"]
 	path = includes/vendor/wds-wp-rest-api-connect
-	url = git@github.com:WebDevStudios/WDS-WP-JSON-API-Connect.git
+	url = https://github.com/WebDevStudios/WDS-WP-REST-API-Connect


### PR DESCRIPTION
Since I don't have permissions on the git repo being used as submodule, I can't checkout using git protocol. Switching to https allows me to.
